### PR TITLE
ZetaSQL Toolkit: Use correct catalog when analyzing

### DIFF
--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/ZetaSQLToolkitAnalyzer.java
@@ -142,7 +142,7 @@ public class ZetaSQLToolkitAnalyzer {
 
         ResolvedStatement statement =
             Analyzer.analyzeNextStatement(
-                parseResumeLocation, analyzerOptions, catalog.getZetaSQLCatalog());
+                parseResumeLocation, analyzerOptions, catalogForAnalysis.getZetaSQLCatalog());
 
         this.previous = Optional.of(statement);
 


### PR DESCRIPTION
Fixes a bug where the ZetaSQL Toolkit would fail to properly analyze SQL scripts with `CREATE` statements because it was using an incorrect catalog. 