### PR TITLE
Bump ZetaSQL dependency to version 2023.03.2

### DIFF
--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.google.zetasql.toolkit</groupId>
     <artifactId>zetasql-toolkit-core</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.version>2022.08.1</zetasql.version>
+        <zetasql.version>2023.03.2</zetasql.version>
         <antlr4.version>4.12.0</antlr4.version>
         <google.cloud.libraries.version>25.4.0</google.cloud.libraries.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/basic/BasicCatalogWrapper.java
@@ -42,7 +42,7 @@ public class BasicCatalogWrapper implements CatalogWrapper {
 
   public BasicCatalogWrapper() {
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(new ZetaSQLBuiltinFunctionOptions());
+    this.catalog.addZetaSQLFunctionsAndTypes(new ZetaSQLBuiltinFunctionOptions());
   }
 
   public BasicCatalogWrapper(SimpleCatalog initialCatalog) {

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProvider.java
@@ -23,6 +23,7 @@ import com.google.zetasql.*;
 import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
 import com.google.zetasql.StructType.StructField;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ProcedureArgumentMode;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -339,7 +340,7 @@ public class BigQueryAPIResourceProvider implements BigQueryResourceProvider {
 
     FunctionArgumentTypeOptions options =
         FunctionArgumentTypeOptions.builder()
-            .setArgumentName(argument.getName())
+            .setArgumentName(argument.getName(), NamedArgumentKind.POSITIONAL_ONLY)
             .setProcedureArgumentMode(procedureArgumentMode)
             .build();
 

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryBuiltIns.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryBuiltIns.java
@@ -26,6 +26,7 @@ import com.google.zetasql.Type;
 import com.google.zetasql.TypeFactory;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ArgumentCardinality;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.Mode;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -69,19 +70,20 @@ class BigQueryBuiltIns {
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("expression")
+                                  .setArgumentName("expression", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               SignatureArgumentKind.ARG_TYPE_ANY_1,
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_value_literal")
+                                  .setArgumentName(
+                                      "search_value_literal", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("json_scope")
+                                  .setArgumentName("json_scope", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1)),
@@ -98,26 +100,27 @@ class BigQueryBuiltIns {
                           new FunctionArgumentType(
                               SignatureArgumentKind.ARG_TYPE_ANY_1,
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_data")
+                                  .setArgumentName("search_data", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("search_query")
+                                  .setArgumentName(
+                                      "search_query", NamedArgumentKind.POSITIONAL_ONLY)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("json_scope")
+                                  .setArgumentName("json_scope", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1),
                           new FunctionArgumentType(
                               TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                               FunctionArgumentTypeOptions.builder()
-                                  .setArgumentName("analyzer")
+                                  .setArgumentName("analyzer", NamedArgumentKind.POSITIONAL_ONLY)
                                   .setCardinality(ArgumentCardinality.OPTIONAL)
                                   .build(),
                               1)),
@@ -134,7 +137,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("session_id")
+                              .setArgumentName("session_id", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.OPTIONAL)
                               .build(),
                           1)),
@@ -148,7 +151,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("job")
+                              .setArgumentName("job", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),
@@ -162,7 +165,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("table_name")
+                              .setArgumentName("table_name", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),
@@ -176,7 +179,7 @@ class BigQueryBuiltIns {
                       new FunctionArgumentType(
                           TypeFactory.createSimpleType(TypeKind.TYPE_STRING),
                           FunctionArgumentTypeOptions.builder()
-                              .setArgumentName("view_name")
+                              .setArgumentName("view_name", NamedArgumentKind.POSITIONAL_ONLY)
                               .setCardinality(ArgumentCardinality.REQUIRED)
                               .build(),
                           1)),

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryCatalog.java
@@ -84,7 +84,7 @@ public class BigQueryCatalog implements CatalogWrapper {
     this.defaultProjectId = defaultProjectId;
     this.bigQueryResourceProvider = bigQueryResourceProvider;
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(
+    this.catalog.addZetaSQLFunctionsAndTypes(
         new ZetaSQLBuiltinFunctionOptions(BigQueryLanguageOptions.get()));
     BigQueryBuiltIns.addToCatalog(this.catalog);
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/catalog/spanner/SpannerCatalog.java
@@ -61,7 +61,7 @@ public class SpannerCatalog implements CatalogWrapper {
     this.database = database;
     this.spannerResourceProvider = spannerResourceProvider;
     this.catalog = new SimpleCatalog("catalog");
-    this.catalog.addZetaSQLFunctions(
+    this.catalog.addZetaSQLFunctionsAndTypes(
         new ZetaSQLBuiltinFunctionOptions(SpannerLanguageOptions.get()));
     SpannerBuiltIns.addToCatalog(this.catalog);
   }

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/main/java/com/google/zetasql/toolkit/usage/UsageTracking.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableMap;
 public class UsageTracking {
 
   private static final String USER_AGENT_HEADER = "user-agent";
-  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.0";
+  private static final String USER_AGENT_VALUE = "google-pso-tool/zetasql-toolkit/0.1.1";
 
   public static final HeaderProvider HEADER_PROVIDER =
       FixedHeaderProvider.create(ImmutableMap.of(USER_AGENT_HEADER, USER_AGENT_VALUE));

--- a/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
+++ b/tools/zetasql-helper/zetasql-toolkit-core/src/test/java/com/google/zetasql/toolkit/catalog/bigquery/BigQueryAPIResourceProviderTest.java
@@ -27,6 +27,7 @@ import com.google.zetasql.*;
 import com.google.zetasql.FunctionArgumentType.FunctionArgumentTypeOptions;
 import com.google.zetasql.StructType.StructField;
 import com.google.zetasql.TVFRelation.Column;
+import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.NamedArgumentKind;
 import com.google.zetasql.ZetaSQLFunctions.FunctionEnums.ProcedureArgumentMode;
 import com.google.zetasql.ZetaSQLFunctions.SignatureArgumentKind;
 import com.google.zetasql.ZetaSQLType.TypeKind;
@@ -217,7 +218,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);
@@ -288,7 +289,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);
@@ -339,7 +340,7 @@ public class BigQueryAPIResourceProviderTest {
         new FunctionArgumentType(
             TypeFactory.createSimpleType(TypeKind.TYPE_INT64),
             FunctionArgumentTypeOptions.builder()
-                .setArgumentName("x")
+                .setArgumentName("x", NamedArgumentKind.POSITIONAL_ONLY)
                 .setProcedureArgumentMode(ProcedureArgumentMode.NOT_SET)
                 .build(),
             1);

--- a/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-examples/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <zetasql.toolkit.version>0.1-SNAPSHOT</zetasql.toolkit.version>
+        <zetasql.toolkit.version>0.1.1-SNAPSHOT</zetasql.toolkit.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <container.mainClass/>
     </properties>


### PR DESCRIPTION
Bumps the ZetaSQL version for the ZetaSQL Toolkit to 2023.03.2. This version includes the recently added access to the `Parser` and the `ParseTreeVisitor`.