### PR TITLE
Avoid dependency conflicts between ZetaSQL and Google Cloud client libraries

### DIFF
--- a/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
+++ b/tools/zetasql-helper/zetasql-toolkit-core/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zetasql.version>2023.03.2</zetasql.version>
         <antlr4.version>4.12.0</antlr4.version>
-        <google.cloud.libraries.version>25.4.0</google.cloud.libraries.version>
+        <google.cloud.libraries.version>26.11.0</google.cloud.libraries.version>
         <google.cloud.jib.version>3.3.1</google.cloud.jib.version>
         <junit.version>5.9.2</junit.version>
         <mockito.version>5.2.0</mockito.version>
@@ -26,6 +26,12 @@
             <groupId>com.google.zetasql</groupId>
             <artifactId>zetasql-client</artifactId>
             <version>${zetasql.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-javalite</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.zetasql/zetasql-types -->
         <dependency>
@@ -49,6 +55,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.cloud/google-cloud-spanner -->
         <dependency>


### PR DESCRIPTION
Avoids dependency conflicts between ZetaSQL and Google Cloud client libraries; caused by transitive dependencies to protobuf, netty and other dependencies.